### PR TITLE
fix removal of "News and Interests"

### DIFF
--- a/tasks/taskbar.yml
+++ b/tasks/taskbar.yml
@@ -20,10 +20,11 @@
 
 - name: Ensure 'News and Interests' unpinned from Taskbar.
   ansible.windows.win_regedit:
-    path: HKCU:\Software\Microsoft\Windows\CurrentVersion\Feeds
-    name: ShellFeedsTaskbarViewMode
-    data: 2
+    path: HKLM:\SOFTWARE\Policies\Microsoft\Windows\Windows Feeds
+    name: EnableFeeds
+    data: 0
     type: dword
+    state: present
 
 - name: Ensure 'People' unpinned from Taskbar.
   ansible.windows.win_regedit:


### PR DESCRIPTION
The Windows registry does not honour the changes made by your task, it simply would not change the value. Adding this new value ensures "News and Interests" is gone for good, even from the context menu.